### PR TITLE
Install from ISO image is now working...

### DIFF
--- a/src/ch/fhnw/dlcopy/DLCopy.java
+++ b/src/ch/fhnw/dlcopy/DLCopy.java
@@ -23,7 +23,6 @@ import ch.fhnw.util.MountInfo;
 import ch.fhnw.util.Partition;
 import ch.fhnw.util.ProcessExecutor;
 import ch.fhnw.util.StorageDevice;
-import ch.fhnw.util.StorageTools;
 import java.applet.Applet;
 import java.applet.AudioClip;
 import java.awt.*;
@@ -90,6 +89,11 @@ public class DLCopy extends JFrame
      * the size of the boot partition (given in MiB)
      */
     public final static long BOOT_PARTITION_SIZE = 100;
+
+    /**
+     * Scale factor for system partition sizing.
+     */
+    public static final float SYSTEM_SIZE_FACTOR = 1.1f;
 
     /**
      * the known partition states for a drive
@@ -354,8 +358,8 @@ public class DLCopy extends JFrame
                 "/ch/fhnw/dlcopy/icons/usbpendrive_unmount.png");
         setIconImage(new ImageIcon(imageURL).getImage());
 
-        systemSize = StorageTools.getSystemSize();
-        systemSizeEnlarged = StorageTools.getEnlargedSystemSize();
+        systemSize = source.getSystemSize();
+        systemSizeEnlarged = (long) (systemSize * SYSTEM_SIZE_FACTOR);
         String sizeString = LernstickFileTools.getDataVolumeString(
                 systemSizeEnlarged, 1);
 

--- a/src/ch/fhnw/dlcopy/InstallationSource.java
+++ b/src/ch/fhnw/dlcopy/InstallationSource.java
@@ -16,7 +16,7 @@ public interface InstallationSource {
             + "|efi.img|lernstick.ico|autorun.inf";
     public final static String BOOT_COPY_PATTERN
             = EXCHANGE_BOOT_COPY_PATTERN
-            + "|isolinux.*|.VolumeIcon.icns|live/memtest";
+            + "|syslinux.*|isolinux.*|.VolumeIcon.icns|live/memtest";
     public final static String SYSTEM_COPY_PATTERM
             = "\\.disk.*|live/filesystem.*|md5sum.txt";
 
@@ -38,6 +38,8 @@ public interface InstallationSource {
     public DebianLiveVersion getSystemVersion();
 
     public String getSystemPath();
+
+    public long getSystemSize();
 
     // Source definitions for copy jobs
     // Partitions may be mounted as needed if not already available

--- a/src/ch/fhnw/dlcopy/IsoInstallationSource.java
+++ b/src/ch/fhnw/dlcopy/IsoInstallationSource.java
@@ -5,6 +5,7 @@ import ch.fhnw.util.LernstickFileTools;
 import ch.fhnw.util.Partition;
 import ch.fhnw.util.ProcessExecutor;
 import ch.fhnw.util.StorageDevice;
+import ch.fhnw.util.StorageTools;
 import java.io.File;
 import java.io.IOException;
 import java.util.logging.Level;
@@ -73,6 +74,12 @@ public class IsoInstallationSource implements InstallationSource {
     @Override
     public String getSystemPath() {
         return mediaPath;
+    }
+
+    @Override
+    public long getSystemSize() {
+        File system = new File(getSystemPath());
+        return system.getTotalSpace() - system.getFreeSpace();
     }
 
     @Override

--- a/src/ch/fhnw/dlcopy/SystemInstallationSource.java
+++ b/src/ch/fhnw/dlcopy/SystemInstallationSource.java
@@ -110,12 +110,16 @@ public final class SystemInstallationSource implements InstallationSource {
     }
 
     @Override
+    public long getSystemSize() {
+        return StorageTools.getSystemSize();
+    }
+
+    @Override
     public Source getBootCopySource() throws DBusException {
         if (hasBootPartition()) {
             mountBootIfNeeded();
-            return new Source(bootPath, ".*");
+            return new Source(bootPath, InstallationSource.BOOT_COPY_PATTERN);
         } else {
-            // shared medium - need to copy select targets explicitly
             return new Source(getSystemPath(),
                     InstallationSource.BOOT_COPY_PATTERN);
         }
@@ -135,13 +139,8 @@ public final class SystemInstallationSource implements InstallationSource {
 
     @Override
     public Source getSystemCopySource() {
-        if (hasBootPartition()) {
-            return new Source(getSystemPath(), ".*");
-        } else {
-            // shared medium - copy squashfs filesystem image only
-            return new Source(getSystemPath(),
-                    InstallationSource.SYSTEM_COPY_PATTERM);
-        }
+        return new Source(getSystemPath(),
+                InstallationSource.SYSTEM_COPY_PATTERM);
     }
 
     @Override


### PR DESCRIPTION
The problem was that the system partition of the debian 7 image was larger than the test system we are using and the partition size was calculated based on the running system. Getting the system size now from the installation source fixes the problem.

I also changed to always use the explicit file pattern for the copy sources. They have to be correct for ISO install (form boot DVD or image) and don't get tested as much during development. The fewer logical branches in the behavior the better...